### PR TITLE
作業/休憩タイマーの自動切り替えと時間入力UIを追加

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,16 +1,20 @@
 //------------------------
 //要素取得
 //------------------------
-let timerDisplay = document.getElementById("timer-display") //表示時刻の要素
+let timerDisplay = document.getElementById("timer-display") //時刻表示
 const playPauseBtn = document.getElementById("playpause-button")
 const resetBtn = document.getElementById("reset-button")
+const workInput = document.getElementById("work-input")
+const breakInput = document.getElementById("break-input")
+const setBtn = document.getElementById("set-button")
 //------------------------
 // 状態
 //------------------------
 let isRunning = "stopped" //タイマー実行フラグ
+let mode = "work" // "work" | "break"
 
 //------------------------
-//グローバル変数定義]
+//グローバル変数定義
 //------------------------
 let endTime = null
 let pauseStartTime = null
@@ -18,6 +22,14 @@ let pauseFinishTime = null
 /**@type {"running" | "stopped" | "paused"} */
 let intervalId = null //setIntervalを行った際の処理ID
 let minutes = null
+
+//----------------------------------
+// 初期設定
+//----------------------------------
+minutes = 25
+timerDisplay.textContent = formatTime(minutes * 60)
+workInput.value = 25
+breakInput.value = 5
 
 //----------------------------------
 // ロジック関数定義
@@ -28,24 +40,39 @@ function formatTime(totalSeconds) {
   return mins + ":" + secs
 }
 
+function startTimer() {
+    intervalId = setInterval(() => {
+        const remaining = Math.floor((endTime - Date.now()) / 1000)
+        if (remaining <= 0) {
+            clearInterval(intervalId)
+            // 作業時間が終わったとき
+            if (mode == "work"){
+                mode = "break"
+                minutes = Number(breakInput.value)
+            } 
+            // 休憩時間が終わったとき
+            else {
+                mode = "work"
+                minutes = Number(workInput.value)
+            }
+            endTime = Date.now() + minutes * 60 * 1000
+            startTimer()
+            return
+        }
+        timerDisplay.textContent = formatTime(remaining)
+    }, 100)
+}
+
 function updateButton() {
-  playPauseBtn.classList.remove("timer__play-button", "timer__pause-button")
-  console.log("クラスリスト",playPauseBtn.classList)
-  console.log("isRunning",isRunning)
+  playPauseBtn.classList.remove("timer__button--play", "timer__button--pause")
 
   if (isRunning === "running") {
-    playPauseBtn.classList.add("timer__pause-button")
+    playPauseBtn.classList.add("timer__button--pause")
   } else {
-    playPauseBtn.classList.add("timer__play-button")
+    playPauseBtn.classList.add("timer__button--play")
   }
 }
 
-
-//----------------------------------
-// 初期設定
-//----------------------------------
-minutes = 25
-timerDisplay.textContent = formatTime(minutes * 60)
 //-----------------------------------------
 // スタートボタン
 //-----------------------------------------
@@ -56,17 +83,7 @@ const playPause = () => {
         isRunning = "running"
         endTime = Date.now() + minutes * 60 * 1000
         // 0.1秒ごとに残り時間を計算し画面に反映(setIntervalIdでブラウザに処理内容を登録)
-        intervalId = setInterval(() => {
-            const remaining = Math.floor((endTime - Date.now()) / 1000)
-            if (remaining <= 0) {
-                timerDisplay.textContent="00:00"
-                isRunning = "stopped"
-                clearInterval(intervalId)
-                updateButton()
-                return
-            }
-            timerDisplay.textContent = formatTime(remaining)
-        }, 100);
+        startTimer()
     }
     // 作動中の場合
     else if (isRunning == "running") {
@@ -81,17 +98,7 @@ const playPause = () => {
         pauseFinishTime = Date.now()// ポーズ終了時刻を取得
         endTime = endTime + (pauseFinishTime - pauseStartTime)
         // 0.1秒ごとに残り時間を計算し画面に反映(setIntervalIdでブラウザに処理内容を登録)
-        intervalId = setInterval(() => {
-            const remaining = Math.floor((endTime - Date.now()) / 1000)
-            if (remaining <= 0) {
-                timerDisplay.textContent="00:00"
-                isRunning = "stopped"
-                clearInterval(intervalId)
-                updateButton()
-                return
-            } 
-            timerDisplay.textContent = formatTime(remaining)
-        }, 100);
+        startTimer()
     }
     updateButton()
 }
@@ -103,8 +110,32 @@ playPauseBtn.addEventListener("click",playPause)
 const reset = () => {
     //作動中なら作動中フラグをオフにする
     isRunning = "stopped"
+    mode = "work"
+    minutes = Number(workInput.value)
     clearInterval(intervalId)
     timerDisplay.textContent = formatTime(minutes * 60)
     updateButton()
 }
 resetBtn.addEventListener("click",reset)
+
+//-----------------------------------------
+// タイマーセットボタン
+//-----------------------------------------
+const workInputSet = () =>{
+    minutes = Number(workInput.value)
+    timerDisplay.textContent = formatTime(Number(workInput.value) * 60)
+}
+workInput.addEventListener("input",workInputSet)
+
+// Enter押したらonBlur
+const blurOnEnter = (e) => {
+  if (e.key === "Enter") {
+    e.target.blur()
+  }
+}
+workInput.addEventListener("keydown", blurOnEnter)
+breakInput.addEventListener("keydown", blurOnEnter)
+// クリックしたら全選択
+const selectOnFocus = (e) => e.target.select()
+workInput.addEventListener("focus", selectOnFocus)
+breakInput.addEventListener("focus", selectOnFocus)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,15 +13,25 @@
             </nav>
         </header>
 
-        <main class="">
-            <section class="timer">
-                <div id="timer-display" class="timer__display"></div>
-                <div>
-                    <button id="playpause-button" class="timer__play-button"></button>
-                    <button id="reset-button" class="timer__reset-button"></button>
-                </div>
-
-            </section>
+        <main class="timer">
+            <!-- 時刻表示 -->
+            <div id="timer-display" class="timer__display"></div>
+            <!-- 再生/一時停止/停止ボタン -->
+            <div class="timer__controls">
+                <button id="playpause-button" class="timer__button timer__button--play"></button>
+                <button id="reset-button" class="timer__button timer__button--reset"></button>
+            </div>
+            <!-- 時間設定欄 -->
+            <div class="timer__settings">
+                <!-- 作業時間設定 -->
+                <label class="timer__label">作業時間:</label>
+                <input id="work-input" class="timer__input">
+                <label class="timer__unit">分</label>
+                <!-- 休憩時間設定 -->
+                <label class="timer__label">休憩:</label>
+                <input id="break-input" class="timer__input">
+                <label class="timer__unit">分</label>
+            </div>
         </main>
     </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -22,7 +22,6 @@ main {
 .nav {
     /* 並びして指定 */
     display: flex;
-    flex-direction: column;
     position: fixed;
     /* 位置指定 */
     top: 10px;
@@ -64,21 +63,23 @@ main {
     align-items: center;
 }
 
+.timer__controls {
+    height: 70px;
+    display:flex;
+    align-items:center;
+}
 /* ボタン共通 */
-.timer__play-button,
-.timer__pause-button,
-.timer__reset-button {
+.timer__button {
     position: relative;
     width: 60px;
     height: 60px;
-    margin-top: 50px;
     border: solid 3px white;
     border-radius: 50%;
     background-color: transparent;
 }
 
 /* 再生ボタン：▶ */
-.timer__play-button::before {
+.timer__button--play::before {
     content: "";
     position: absolute;
     top: 50%;
@@ -92,8 +93,8 @@ main {
 }
 
 /* 一時停止ボタン：❚❚ */
-.timer__pause-button::before,
-.timer__pause-button::after {
+.timer__button--pause::before,
+.timer__button--pause::after {
     content: "";
     position: absolute;
     top: 50%;
@@ -102,15 +103,15 @@ main {
     height: 22px;
     background-color: white;
 }
-.timer__pause-button::before {
+.timer__button--pause::before {
     left: 30%;
 }
-.timer__pause-button::after {
+.timer__button--pause::after {
     right: 30%;
 }
 
 /* 停止ボタン：■ */
-.timer__reset-button::before {
+.timer__button--reset::before {
     content: "";
     position: absolute;
     top: 50%;
@@ -119,4 +120,48 @@ main {
     width: 22px;
     height: 22px;
     background-color: white;
+}
+
+.timer__settings {
+    display: flex;
+    align-items: end;
+    gap: 4px;
+    margin-left: 30px;
+}
+
+.timer__input {
+    width: 30px;
+    height: 25px;
+    font-size: larger;
+    color: rgb(255, 255, 255);
+    background-color: rgba(255, 255, 255, 0);
+    border: solid 2px;
+    border-color: rgb(255, 255, 255);
+    border-radius: 10%;
+    text-align: center;
+}
+
+.timer__label {
+    color: white;
+    font-size: 1.5rem;
+}
+
+.timer__unit {
+    color: white;
+    font-size: 1.5rem;
+}
+
+.timer__button--set {
+    width: 70px;
+    height: 30px;
+    color: white;
+    background-color:  rgba(255, 255, 255, 0.7);
+    border: solid 2px white;
+    border-radius: 10%;
+    font-size: 1rem;
+    padding: 4px 8px;
+}
+.timer__button--set:active {
+  transform: translateY(2px);
+  box-shadow: 0 0 0 #333;
 }


### PR DESCRIPTION
## 変更概要

- `startTimer()` 関数を追加し、`setInterval` のコールバックを一本化
- 作業タイマーが終了すると自動で休憩タイマーへ切り替わり、休憩終了後は再び作業タイマーへループする
- 作業時間・休憩時間の入力欄を追加（初期値: 作業25分 / 休憩5分）
- Enterキーでフォーカス解除、クリックで全選択のUX改善
- `mode` 変数（`"work"` | `"break"`）でタイマーの状態を管理
- BEM記法のクラス名修正、デバッグ用 `console.log` 削除

## テスト項目

### 初期表示
- [x] タイマーが `25:00` で表示される
- [x] 作業時間inputに `25` が表示される
- [x] 休憩時間inputに `5` が表示される
- [x] 再生ボタン（▶）が表示される

### 再生ボタン
- [x] 押すとタイマーがカウントダウンを開始する
- [x] 押すと一時停止ボタン（❚❚）に切り替わる
- [x] カウントダウン中、表示が1秒ごとに更新される
- [x] `25:00` → `24:59` → ... と正しく減っていく

### 一時停止
- [x] 実行中に押すと一時停止する
- [x] 一時停止中、タイマー表示が止まる
- [x] 一時停止中、再生ボタン（▶）に切り替わる
- [x] 一時停止後に再開すると、止まった時刻から再開する（時間が飛ばない）
- [x] 一時停止を複数回繰り返しても時間がずれない

### リセットボタン
- [x] 実行中に押すとタイマーが止まる
- [x] 一時停止中に押すとタイマーが止まる
- [x] 押すと作業時間inputの値で表示がリセットされる
- [x] 押すと再生ボタン（▶）に戻る
- [x] リセット後に再度スタートできる

### 作業時間終了 → 休憩タイマー
- [x] `00:00` になると自動的に休憩タイマーが始まる
- [x] 休憩タイマーはbreakInputの値（デフォルト5分）でカウントダウンされる
- [x] 休憩タイマー中も一時停止・再開できる
- [x] 休憩タイマー中にリセットすると作業時間inputの値で表示がリセットされる

### 休憩タイマー終了 → 作業タイマー
- [x] 休憩の `00:00` になると自動的に次の作業タイマーが始まる
- [x] 作業タイマーはworkInputの値でカウントダウンされる

### 作業時間input
- [x] 値を変更するとタイマー表示に即時反映される（停止中）
- [x] クリックすると全選択される
- [x] Enterキーでフォーカスが外れる
- [x] 実行中に値を変えても現在のタイマーには影響しない（リセット後に反映）

### 休憩時間input
- [x] クリックすると全選択される
- [x] Enterキーでフォーカスが外れる